### PR TITLE
fix: Add support for Japanese slash date without year

### DIFF
--- a/src/textlint-rule-date-weekday-mismatch.js
+++ b/src/textlint-rule-date-weekday-mismatch.js
@@ -58,10 +58,6 @@ const detectLang = (tags, preferLang) => {
  * @returns {string}
  */
 const addYearToDateText = (dateText, year, lang) => {
-    // Japanese: 4月23日(月) → 2024年4月23日(月)
-    if (lang === "ja") {
-        return `${year}年${dateText}`;
-    }
     // Slash: 4/23(月) → 2024/4/23(月)
     if (/^[0-9]{1,2}\/[0-9]{1,2}/.test(dateText)) {
         return `${year}/${dateText}`;
@@ -69,6 +65,10 @@ const addYearToDateText = (dateText, year, lang) => {
     // Dash: 4-23(Mon) → 2024-4-23(Mon)
     if (/^[0-9]{1,2}-[0-9]{1,2}/.test(dateText)) {
         return `${year}-${dateText}`;
+    }
+    // Japanese: 4月23日(月) → 2024年4月23日(月)
+    if (lang === "ja") {
+        return `${year}年${dateText}`;
     }
     // Default: prepend year and a space
     return `${year} ${dateText}`;

--- a/test/textlint-rule-date-weekday-mismatch-test.js
+++ b/test/textlint-rule-date-weekday-mismatch-test.js
@@ -31,6 +31,11 @@ tester.run("rule", rule, {
             options: { useCurrentYearIfMissing: true, currentYear: 2025, lang: "en" },
             // 2025-04-23 is Wednesday
         },
+        {
+            text: "6/20(金)",
+            options: { useCurrentYearIfMissing: true, currentYear: 2025, lang: "ja" },
+            // 2025/06/20は金曜日
+        },
     ],
     invalid: [
         // single match
@@ -154,6 +159,18 @@ tester.run("rule", rule, {
             errors: [
                 {
                     message: "4/23(Fri) mismatch weekday.\n4/23(Fri) => 4/23(Wed)",
+                    line: 1,
+                    column: 6
+                }
+            ]
+        },
+        {
+            text: "6/20(木)",
+            output: "6/20(金)",
+            options: { useCurrentYearIfMissing: true, currentYear: 2025, lang: "ja" },
+            errors: [
+                {
+                    message: "6/20(木) mismatch weekday.\n6/20(木) => 6/20(金)",
                     line: 1,
                     column: 6
                 }


### PR DESCRIPTION
## Summary

Fixes a bug where year-less, slash-separated dates (e.g., `6/20(木)`) failed to parse correctly when the `lang: "ja"` option was active.

## Details

- Reorders the conditional checks in the `addYearToDateText` function to prioritize generic date formats over language-specific ones.
- The previous logic incorrectly formatted slash-separated dates as `2025年6/20(木)`, which broke the date parser.
- The new logic ensures slash (`/`) and dash (`-`) formats are handled first, guaranteeing correct year supplementation.

## Behavior Before vs. After

With options `{ useCurrentYearIfMissing: true, currentYear: 2025, lang: "ja" }`:

**Before**
- **Input**: `"6/20(木)"`
- **Result**: Fails to detect weekday mismatch.

**After**
- **Input**: `"6/20(木)"`
- **Result**: `6/20(木) mismatch weekday.\n6/20(木) => 6/20(金)`

## Background

This patch addresses an edge case not covered in the initial implementation of the `useCurrentYearIfMissing` option (see [#14](https://github.com/textlint-rule/textlint-rule-date-weekday-mismatch/pull/14)), improving the rule's reliability for common date formats in Japanese.